### PR TITLE
Working Coulombic efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,19 @@
 ## [Unreleased](https://github.com/NREL/thevenin)
 
 ### New Features
+- Added Coulombic efficiency (`ce`) as a parameter option ([#4](https://github.com/NREL/thevenin/pull/4))
 
 ### Optimizations
 
 ### Bug Fixes
 
 ### Breaking Changes
+- New Coulombic efficiency option means users will need to update old `params` inputs to also include `ce`
+
+## [v0.1.1](https://github.com/NREL/thevenin/tree/v0.1.1)
+
+### Bug Fixes
+- Corrected some docstrings
 
 ## [v0.1.0](https://github.com/NREL/thevenin/tree/v0.1.0)
 This is the first official release of `thevenin`. Main features/capabilities are listed below.

--- a/images/tests.svg
+++ b/images/tests.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 32">
-	<title>tests: 32</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 33">
+	<title>tests: 33</title>
 	<linearGradient id="s" x2="0" y2="100%">
 		<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
 		<stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
 	<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
 		<text aria-hidden="true" x="195.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">tests</text>
 		<text x="195.0" y="140" transform="scale(.1)" fill="#fff" textLength="270">tests</text>
-		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">32</text>
-		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">32</text>
+		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">33</text>
+		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">33</text>
 	</g>
 </svg>

--- a/src/thevenin/__init__.py
+++ b/src/thevenin/__init__.py
@@ -27,7 +27,7 @@ from ._solutions import StepSolution, CycleSolution
 from . import loadfns
 from . import plotutils
 
-__version__ = '0.1.1'
+__version__ = '0.1.2.dev'
 
 __all__ = [
     'IDASolver',

--- a/src/thevenin/_model.py
+++ b/src/thevenin/_model.py
@@ -42,6 +42,7 @@ class Model:
             num_RC_pairs  number of RC pairs         *int*, -
             soc0          initial state of charge    *float*, -
             capacity      maximum battery capacity   *float*, Ah
+            ce            coulombic efficiency       *float*, -
             mass          total battery mass         *float*, kg
             isothermal    flag for isothermal model  *bool*, -
             Cp            specific heat capacity     *float*, J/kg/K
@@ -92,6 +93,7 @@ class Model:
             'num_RC_pairs',
             'soc0',
             'capacity',
+            'ce',
             'mass',
             'isothermal',
             'Cp',
@@ -103,6 +105,7 @@ class Model:
         self.num_RC_pairs = params.pop('num_RC_pairs')
         self.soc0 = params.pop('soc0')
         self.capacity = params.pop('capacity')
+        self.ce = params.pop('ce')
         self.mass = params.pop('mass')
         self.isothermal = params.pop('isothermal')
         self.Cp = params.pop('Cp')
@@ -302,7 +305,8 @@ class Model:
         power = current*voltage
 
         # state of charge (differential)
-        rhs[self._ptr['soc']] = -current / 3600. / self.capacity
+        ce = 1. if current >= 0. else self.ce
+        rhs[self._ptr['soc']] = -ce*current / 3600. / self.capacity
 
         # temperature (differential)
         Q_gen = current*(ocv - voltage)

--- a/src/thevenin/templates/params.yaml
+++ b/src/thevenin/templates/params.yaml
@@ -1,6 +1,7 @@
 num_RC_pairs: 1
 soc0: 1.
 capacity: 75.
+ce: 1.
 mass: 1.9
 isothermal: False
 Cp: 745.


### PR DESCRIPTION
# Description
This PR adds Coulombic efficiency to the model. Users must now specify `ce` as an input parameter. The Coulombic efficiency only affects how the `soc` evolves in time during charging:

```python
ce = 1. if current >= 0. else model.ce
dsoc_dt = -ce*current / 3600. / model.capacity
```

Resolves #3 

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that improves speed/readability/etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

The optional `-- format` and `-- write` arguments (see above) attempt to correct formatting issues prior to running the linter, and spelling mistakes prior to running the spellcheck, respectively. You can also run all of the above checks using `$ nox -s pre-commit` instead of running them individually.

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
