### PR TITLE
Allow CycleSolution to append additional solutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## [Unreleased](https://github.com/NREL/thevenin)
 
 ### New Features
-- Added hysteresis (`hsyt`) to the model, controlled with `gamma` and `M_hyst` parameters ([#7](https://github.com/NREL/thevenin/pull/7))
+- Allow the `CycleSolution` to append more solutions after it has been initialized ([#9](https://github.com/NREL/thevenin/pull/9))
 - New `Prediction` and `TransientState` classes for an improved interface to Kalman filters ([#8](https://github.com/NREL/thevenin/pull/8))
+- Added hysteresis (`hsyt`) to the model, controlled with `gamma` and `M_hyst` parameters ([#7](https://github.com/NREL/thevenin/pull/7))
 
 ### Optimizations
 - Pre-initialize `CycleSolution` arrays rather than appending lists, much faster ([#7](https://github.com/NREL/thevenin/pull/7))
@@ -13,7 +14,7 @@
 ### Bug Fixes
 
 ### Breaking Changes
-- New hysteresis option means users will need to update old `params` inputs to also include `gamma` and `M_hyst`
+- New hysteresis option means users will need to update old `params` inputs to also include `gamma` and `M_hyst` ([#7](https://github.com/NREL/thevenin/pull/7))
 
 ## [v0.1.2](https://github.com/NREL/thevenin/tree/v0.1.2)
 

--- a/images/tests.svg
+++ b/images/tests.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 38">
-	<title>tests: 38</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 43">
+	<title>tests: 43</title>
 	<linearGradient id="s" x2="0" y2="100%">
 		<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
 		<stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
 	<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
 		<text aria-hidden="true" x="195.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">tests</text>
 		<text x="195.0" y="140" transform="scale(.1)" fill="#fff" textLength="270">tests</text>
-		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">38</text>
-		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">38</text>
+		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">43</text>
+		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">43</text>
 	</g>
 </svg>

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -6,7 +6,7 @@ import thevenin as thev
 import matplotlib.pyplot as plt
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='function')  # cannot be module b/c appends
 def soln():
 
     warnings.filterwarnings('ignore')
@@ -14,10 +14,27 @@ def soln():
     sim = thev.Simulation()
 
     expr = thev.Experiment()
-    expr.add_step('current_A', 1., (3600., 1.), limits=('voltage_V', 3.))
-    expr.add_step('current_A', 0., (3600., 1.))
+    expr.add_step('current_C', 1., (3600., 1.), limits=('voltage_V', 3.))
+    expr.add_step('current_A', 0., (300., 1.))
+    expr.add_step('current_C', -1., (3600., 1.), limits=('voltage_V', 4.3))
+    expr.add_step('current_A', 0., (300., 1.))
 
     soln = sim.run(expr)
+
+    return soln
+
+
+@pytest.fixture(scope='function')
+def rest():
+
+    warnings.filterwarnings('ignore')
+
+    sim = thev.Simulation()
+
+    rest = thev.Experiment()
+    rest.add_step('current_A', 0., (300., 1.))
+
+    soln = sim.run(rest)
 
     return soln
 
@@ -52,3 +69,66 @@ def test_step_and_cycle_solutions(soln):
         cycle_soln.plot('soc', 'soc')
         cycle_soln.plot('time_h', 'voltage_V')
         plt.close('all')
+
+
+def test_cycle_from_single_step(soln):
+
+    step0 = soln.get_steps(0)
+    assert isinstance(step0, thev.StepSolution)
+
+    cycle = thev.CycleSolution(step0)
+    assert isinstance(cycle, thev.CycleSolution)
+
+
+def test_append_errors(soln):
+
+    # append wrong size solution (different num_RC_pairs)
+    with pytest.raises(ValueError):
+        step0 = soln.get_steps(0)
+        step0._sim.num_RC_pairs += 1
+        soln.append_soln(step0)
+
+    # only works with StepSolution and CycleSolution
+    with pytest.raises(TypeError):
+        sim = soln._sim
+        soln.append_soln(sim)
+
+
+def test_append_step_soln(soln):
+
+    t_orig = soln.vars['time_s']
+    V_orig = soln.vars['voltage_V']
+
+    step0 = soln.get_steps(0)
+
+    soln.append_soln(step0, t_shift=0.)
+    assert len(soln.success) == 5
+
+    t_new_times = t_orig[-1] + step0.vars['time_s']
+    t_append = np.concatenate([t_orig, t_new_times])
+    np.testing.assert_allclose(soln.vars['time_s'], t_append)
+
+    V_append = np.concatenate([V_orig, step0.vars['voltage_V']])
+    np.testing.assert_allclose(soln.vars['voltage_V'], V_append)
+
+
+def test_append_cycle_soln(soln):
+
+    t_orig = soln.vars['time_s']
+    V_orig = soln.vars['voltage_V']
+
+    soln.append_soln(soln, t_shift=0.)
+    assert len(soln.success) == 8
+
+    t_new_times = t_orig[-1] + t_orig
+    t_append = np.concatenate([t_orig, t_new_times])
+    np.testing.assert_allclose(soln.vars['time_s'], t_append)
+
+    V_append = np.concatenate([V_orig, V_orig])
+    np.testing.assert_allclose(soln.vars['voltage_V'], V_append)
+
+
+def test_append_w_events(rest, soln):
+
+    rest.append_soln(soln)
+    assert len(rest.t_events) == 2


### PR DESCRIPTION
# Description
Allow `CycleSolution` to append additional solutions after it has been initialized. Single method works for appending `StepSolution` or `CycleSolution` instances. Also tested with appending itself.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
