### PR TITLE
Cleanup tests with np.testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@
 - Added hysteresis (`hsyt`) to the model, controlled with `gamma` and `M_hyst` parameters ([#7](https://github.com/NREL/thevenin/pull/7))
 
 ### Optimizations
+- Use `np.testing` where possible in tests for more informative fail statements ([#10](https://github.com/NREL/thevenin/pull/10))
 - Pre-initialize `CycleSolution` arrays rather than appending lists, much faster ([#7](https://github.com/NREL/thevenin/pull/7))
-- Introduce `ExitHandler` to ensure `plt.show` doesn't get registered more than once ([#7](https://github.com/NREL/thevenin/pull/7))
+- Introduce `ExitHandler` to ensure `plt.show` doesn't get registered more than once, replaces `show_plot` option in `Solutions` ([#7](https://github.com/NREL/thevenin/pull/7))
 
 ### Bug Fixes
+None.
 
 ### Breaking Changes
 - New hysteresis option means users will need to update old `params` inputs to also include `gamma` and `M_hyst` ([#7](https://github.com/NREL/thevenin/pull/7))
@@ -25,10 +27,10 @@
 - Bounded exponential input to avoid overflow warnings inside the sigmoid function of `loadfns.Ramp2Constant` ([#6](https://github.com/NREL/thevenin/pull/6))
 
 ### Bug Fixes
-- `*Solution.plot()` now has a `show_plot` option to register `plt.show()` and block at the end of a program ([#5](https://github.com/NREL/thevenin/pull/5)). This keeps figures from auto-closing at the end of scripts run in non-interactive environments. Interactive environments (IPython, Jupyter Notebook) are not affected. When set to `False`, users running in non-interactive environments must manually call `plt.show()`. The default is `True`.
+- `*Solution.plot()` now has a `show_plot` option to register `plt.show` and block at the end of a program ([#5](https://github.com/NREL/thevenin/pull/5))
 
 ### Breaking Changes
-- New Coulombic efficiency option means users will need to update old `params` inputs to also include `ce`
+- New Coulombic efficiency option means users will need to update old `params` inputs to also include `ce` ([#4](https://github.com/NREL/thevenin/pull/4))
 
 ## [v0.1.1](https://github.com/NREL/thevenin/tree/v0.1.1)
 

--- a/docs/source/user_guide/model_description.rst
+++ b/docs/source/user_guide/model_description.rst
@@ -52,7 +52,7 @@ The overall cell voltage is
 .. math:: 
 
     \begin{equation}
-      V_{\rm cell} = V_{\rm OCV}({\rm SOC}) - \sum_j V_j - IR_0,
+      V_{\rm cell} = V_{\rm OCV}({\rm SOC}) + h - \sum_j V_j - IR_0,
     \end{equation}
 
 where :math:`R_0` is the lone series resistance (Ohm), as shown in Figure 1. Just like the other resistive elements, :math:`R_0` is a function of SOC and :math:`T_{\rm cell}`.

--- a/tests/test_basemodel.py
+++ b/tests/test_basemodel.py
@@ -1,8 +1,10 @@
 import warnings
 
 import pytest
-import numpy as np
 import thevenin as thev
+
+import numpy as np
+import numpy.testing as npt
 
 
 def test_model_deprecation():
@@ -39,7 +41,7 @@ def test_calculated_current():
 
     # with 2D eta_j
     eta_j = np.zeros((500, 3))
-    np.testing.assert_allclose(
+    npt.assert_allclose(
         calculated_current(voltage, ocv, hyst, eta_j, R0),
         np.zeros(500),
     )
@@ -64,7 +66,7 @@ def test_calculated_voltage():
 
     # with 2D eta_j
     eta_j = np.zeros((500, 3))
-    np.testing.assert_allclose(
+    npt.assert_allclose(
         calculated_voltage(current, ocv, hyst, eta_j, R0),
         ocv*np.ones(500),
     )

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,6 +1,8 @@
 import pytest
-import numpy as np
 import thevenin as thev
+
+import numpy as np
+import numpy.testing as npt
 
 
 @pytest.fixture(scope='function')
@@ -24,26 +26,26 @@ def test_tspan_construction(expr):
     expr.add_step('current_A', 0., (10., 7))
 
     step = expr._steps[-1]
-    assert np.allclose(step['tspan'], np.linspace(0., 10., 7))
+    npt.assert_allclose(step['tspan'], np.linspace(0., 10., 7))
 
     # using arange - evenly divisible
     expr.add_step('current_A', 0., (10., 2.))
 
     step = expr._steps[-1]
-    assert np.allclose(step['tspan'], np.array([0., 2., 4., 6., 8., 10.]))
+    npt.assert_allclose(step['tspan'], np.array([0., 2., 4., 6., 8., 10.]))
 
     # using arange - not evenly divisible
     expr.add_step('current_A', 0., (10., 3.))
 
     step = expr._steps[-1]
-    assert np.allclose(step['tspan'], np.array([0., 3., 6., 9., 10.]))
+    npt.assert_allclose(step['tspan'], np.array([0., 3., 6., 9., 10.]))
 
     # custom tspan array
     tspan = np.hstack([0., np.logspace(-3, 3, 10)])
     expr.add_step('current_A', 0., tspan)
 
     step = expr._steps[-1]
-    assert np.allclose(step['tspan'], tspan)
+    npt.assert_allclose(step['tspan'], tspan)
 
 
 def test_add_step(expr):
@@ -90,14 +92,14 @@ def test_add_step(expr):
     step = expr.steps[0]
 
     assert expr.num_steps == 1
-    assert np.allclose(step['tspan'], np.linspace(0., 3600., 150))
+    npt.assert_allclose(step['tspan'], np.linspace(0., 3600., 150))
 
     # test voltage and arange construction
     expr.add_step('voltage_V', 4., (3600., 1.))
     step = expr.steps[1]
 
     assert expr.num_steps == 2
-    assert np.allclose(step['tspan'], np.arange(0., 3601., 1., dtype=float))
+    npt.assert_allclose(step['tspan'], np.arange(0., 3601., 1., dtype=float))
 
     # test power construction
     expr.add_step('power_W', 1., (3600., 1.))

--- a/tests/test_loadfns.py
+++ b/tests/test_loadfns.py
@@ -1,6 +1,8 @@
 import pytest
-import numpy as np
 import thevenin as thev
+
+import numpy as np
+import numpy.testing as npt
 
 
 def test_ramp():
@@ -10,7 +12,7 @@ def test_ramp():
     tp = np.linspace(0, 20, 25)
     yp = 5.*tp + 10.
 
-    assert np.allclose(demand(tp), yp)
+    npt.assert_allclose(demand(tp), yp)
 
 
 def test_ramp_2_constant():
@@ -44,12 +46,12 @@ def test_ramp_2_constant():
     tp = np.linspace(0, 1e-3, 10)
     yp = 6./1e-3*tp + 0.
 
-    assert np.allclose(demand(tp), yp)
+    npt.assert_allclose(demand(tp), yp, atol=1e-8)
 
     tp = np.linspace(1e-3, 100, 100)
     yp = 6.*np.ones_like(tp)
 
-    assert np.allclose(demand(tp), yp)
+    npt.assert_allclose(demand(tp), yp)
 
     # negative ramp
     demand = thev.loadfns.Ramp2Constant(-6./1e-3, -6.)
@@ -57,12 +59,12 @@ def test_ramp_2_constant():
     tp = np.linspace(0, 1e-3, 10)
     yp = -6./1e-3*tp + 0.
 
-    assert np.allclose(demand(tp), yp)
+    npt.assert_allclose(demand(tp), yp, atol=1e-8)
 
     tp = np.linspace(1e-3, 100, 100)
     yp = -6.*np.ones_like(tp)
 
-    assert np.allclose(demand(tp), yp)
+    npt.assert_allclose(demand(tp), yp)
 
 
 def test_step_function():
@@ -94,7 +96,7 @@ def test_step_function():
     y_test = np.array([-np.inf, -1, 0, 1])
 
     assert np.isnan(demand(np.nan))
-    assert np.allclose(demand(t_test), y_test, equal_nan=True)
+    npt.assert_allclose(demand(t_test), y_test, equal_nan=True)
 
     demand = thev.loadfns.StepFunction(tp, yp, -np.inf, ignore_nan=True)
 
@@ -135,19 +137,19 @@ def test_ramped_steps():
     t_test = np.array([-1, 0.5, 3, 10])
     y_test = np.array([0, -1, 5, 10])
 
-    assert np.allclose(demand(t_test), y_test)
+    npt.assert_allclose(demand(t_test), y_test)
 
     def ramp(t): return 0. + (-1. - 0.) / 1e-3 * t
     t_test = np.linspace(0, 1e-3, 10)
 
-    assert np.allclose(demand(t_test), ramp(t_test))
+    npt.assert_allclose(demand(t_test), ramp(t_test))
 
     def ramp(t): return -1. + (5. - -1.) / 1e-3 * (t - 1.)
     t_test = np.linspace(1, 1 + 1e-3, 10)
 
-    assert np.allclose(demand(t_test), ramp(t_test))
+    npt.assert_allclose(demand(t_test), ramp(t_test))
 
     def ramp(t): return 5. + (10. - 5.) / 1e-3 * (t - 5.)
     t_test = np.linspace(5, 5 + 1e-3, 10)
 
-    assert np.allclose(demand(t_test), ramp(t_test))
+    npt.assert_allclose(demand(t_test), ramp(t_test))

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -1,8 +1,10 @@
 import warnings
 
 import pytest
-import numpy as np
 import thevenin as thev
+
+import numpy as np
+import numpy.testing as npt
 
 
 def test_prediction_steps_against_simulation():
@@ -62,15 +64,15 @@ def test_prediction_steps_against_simulation():
         for j in range(sim.num_RC_pairs):
             pred_etaj[i+1][j] = state.eta_j[j]
 
-    np.testing.assert_allclose(pred_V, soln.vars['voltage_V'], rtol=1e-3)
-    np.testing.assert_allclose(pred_T, soln.vars['temperature_K'], rtol=1e-3)
+    npt.assert_allclose(pred_V, soln.vars['voltage_V'], rtol=1e-3)
+    npt.assert_allclose(pred_T, soln.vars['temperature_K'], rtol=1e-3)
 
-    np.testing.assert_allclose(
+    npt.assert_allclose(
         pred_h, soln.vars['hysteresis_V'], rtol=1e-3, atol=1e-3,
     )
 
     for j in range(sim.num_RC_pairs):
-        np.testing.assert_allclose(
+        npt.assert_allclose(
             pred_etaj[:, j], soln.vars[f"eta{j+1}_V"], rtol=1e-3, atol=1e-5,
         )
 
@@ -98,8 +100,8 @@ def test_0_RC_pair_pred():
     state = thev.TransientState(soc=1., T_cell=300, hyst=0, eta_j=None)
 
     new_state = pred.take_step(state, 1., 3600.)
-    np.testing.assert_almost_equal(new_state.soc, 0.)
-    np.testing.assert_almost_equal(new_state.voltage, 3., decimal=2)
+    npt.assert_almost_equal(new_state.soc, 0.)
+    npt.assert_almost_equal(new_state.voltage, 3., decimal=2)
 
 
 def test_dynamic_pred_step():
@@ -115,8 +117,8 @@ def test_dynamic_pred_step():
     voltage_0 = pred.ocv(soc_0)
 
     new_state = pred.take_step(state, lambda t: 0., 300.)
-    np.testing.assert_almost_equal(new_state.soc, soc_0)
-    np.testing.assert_almost_equal(new_state.voltage, voltage_0)
+    npt.assert_almost_equal(new_state.soc, soc_0)
+    npt.assert_almost_equal(new_state.voltage, voltage_0)
 
 
 def test_incompatible_state():

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,6 +1,9 @@
 import pytest
-import numpy as np
 import thevenin as thev
+
+import numpy as np
+import numpy.testing as npt
+
 from scipy.integrate import cumulative_trapezoid
 
 
@@ -213,20 +216,20 @@ def test_preprocessing_initial_state_options(sim_0RC, constant_steps):
     svdot0 = sim_0RC._svdot0.copy()
 
     soln = sim_0RC.run(constant_steps)
-    np.testing.assert_allclose(sv0, sim_0RC._sv0)
-    np.testing.assert_allclose(svdot0, sim_0RC._svdot0)
+    npt.assert_allclose(sv0, sim_0RC._sv0)
+    npt.assert_allclose(svdot0, sim_0RC._svdot0)
 
     sim_0RC.pre(initial_state=soln)
-    np.testing.assert_allclose(soln.y[-1], sim_0RC._sv0)
-    np.testing.assert_allclose(soln.yp[-1], sim_0RC._svdot0)
+    npt.assert_allclose(soln.y[-1], sim_0RC._sv0)
+    npt.assert_allclose(soln.yp[-1], sim_0RC._svdot0)
 
     sim_0RC.pre(initial_state=False)
-    np.testing.assert_allclose(soln.y[-1], sim_0RC._sv0)
-    np.testing.assert_allclose(soln.yp[-1], sim_0RC._svdot0)
+    npt.assert_allclose(soln.y[-1], sim_0RC._sv0)
+    npt.assert_allclose(soln.yp[-1], sim_0RC._svdot0)
 
     sim_0RC.pre()
-    np.testing.assert_allclose(sv0, sim_0RC._sv0)
-    np.testing.assert_allclose(svdot0, sim_0RC._svdot0)
+    npt.assert_allclose(sv0, sim_0RC._sv0)
+    npt.assert_allclose(svdot0, sim_0RC._svdot0)
 
 
 def test_run_step(sim_2RC, constant_steps):
@@ -242,8 +245,8 @@ def test_run_step(sim_2RC, constant_steps):
 
     sim_2RC.pre()
 
-    np.testing.assert_allclose(sv0, sim_2RC._sv0)
-    np.testing.assert_allclose(svdot0, sim_2RC._svdot0)
+    npt.assert_allclose(sv0, sim_2RC._sv0)
+    npt.assert_allclose(svdot0, sim_2RC._svdot0)
 
 
 def test_run_options(sim_0RC, constant_steps):
@@ -251,12 +254,12 @@ def test_run_options(sim_0RC, constant_steps):
     svdot0 = sim_0RC._svdot0.copy()
 
     soln = sim_0RC.run(constant_steps)
-    np.testing.assert_allclose(sv0, sim_0RC._sv0)
-    np.testing.assert_allclose(svdot0, sim_0RC._svdot0)
+    npt.assert_allclose(sv0, sim_0RC._sv0)
+    npt.assert_allclose(svdot0, sim_0RC._svdot0)
 
     soln = sim_0RC.run(constant_steps, reset_state=False)
-    np.testing.assert_allclose(soln.y[-1], sim_0RC._sv0)
-    np.testing.assert_allclose(soln.yp[-1], sim_0RC._svdot0)
+    npt.assert_allclose(soln.y[-1], sim_0RC._sv0)
+    npt.assert_allclose(soln.yp[-1], sim_0RC._svdot0)
 
 
 def test_sim_w_multistep_experiment(sim_0RC, sim_1RC, sim_2RC, constant_steps):
@@ -318,7 +321,7 @@ def test_resting_experiment(sim_2RC):
     soln = sim_2RC.run(expr)
 
     assert soln.success
-    np.testing.assert_allclose(
+    npt.assert_allclose(
         soln.vars['voltage_V'],
         soln.vars['voltage_V'][0],
     )
@@ -344,7 +347,7 @@ def test_constant_V_shift_w_constant_R0(sim_0RC, constant_steps):
 
     discharge = soln.get_steps(0)
     ocv = sim_0RC.ocv(discharge.vars['soc'])
-    np.testing.assert_allclose(
+    npt.assert_allclose(
         discharge.vars['voltage_V'],
         ocv - 1e-2,
         rtol=1e-3,
@@ -352,7 +355,7 @@ def test_constant_V_shift_w_constant_R0(sim_0RC, constant_steps):
 
     charge = soln.get_steps(2)
     ocv = sim_0RC.ocv(charge.vars['soc'])
-    np.testing.assert_allclose(
+    npt.assert_allclose(
         charge.vars['voltage_V'],
         ocv + 1e-2,
         rtol=1e-3,
@@ -374,7 +377,7 @@ def test_isothermal_flag(sim_2RC, constant_steps):
     sim_2RC.pre()
 
     soln = sim_2RC.run(constant_steps)
-    np.testing.assert_allclose(soln.vars['temperature_K'], sim_2RC.T_inf)
+    npt.assert_allclose(soln.vars['temperature_K'], sim_2RC.T_inf)
 
 
 @pytest.mark.filterwarnings("ignore:.*default parameter file.*:UserWarning")
@@ -451,32 +454,32 @@ def test_hysteresis():
     charge.add_step('current_A', 0., (600., 10.))
 
     soln = sim_woh.run(discharge, reset_state=False)
-    np.testing.assert_allclose(soln.vars['hysteresis_V'], 0., atol=1e-9)
-    np.testing.assert_almost_equal(
+    npt.assert_allclose(soln.vars['hysteresis_V'], 0., atol=1e-9)
+    npt.assert_almost_equal(
         soln.vars['voltage_V'][-1],
         sim_woh.ocv(0.5),
         decimal=2,
     )
 
     soln = sim_woh.run(charge, reset_state=False)
-    np.testing.assert_allclose(soln.vars['hysteresis_V'], 0., atol=1e-9)
-    np.testing.assert_almost_equal(
+    npt.assert_allclose(soln.vars['hysteresis_V'], 0., atol=1e-9)
+    npt.assert_almost_equal(
         soln.vars['voltage_V'][-1],
         sim_woh.ocv(0.8),
         decimal=2,
     )
 
     soln = sim_wh.run(discharge, reset_state=False)
-    np.testing.assert_allclose(soln.vars['hysteresis_V'][-1], -0.07, rtol=1e-4)
-    np.testing.assert_almost_equal(
+    npt.assert_allclose(soln.vars['hysteresis_V'][-1], -0.07, rtol=1e-4)
+    npt.assert_almost_equal(
         soln.vars['voltage_V'][-1],
         sim_woh.ocv(0.5) - 0.07,
         decimal=2,
     )
 
     soln = sim_wh.run(charge, reset_state=False)
-    np.testing.assert_allclose(soln.vars['hysteresis_V'][-1], 0.07, rtol=1e-4)
-    np.testing.assert_almost_equal(
+    npt.assert_allclose(soln.vars['hysteresis_V'][-1], 0.07, rtol=1e-4)
+    npt.assert_almost_equal(
         soln.vars['voltage_V'][-1],
         sim_woh.ocv(0.8) + 0.07,
         decimal=2,
@@ -484,7 +487,7 @@ def test_hysteresis():
 
     # Check current is unaffected by hysteresis
     step = soln.get_steps(0)
-    np.testing.assert_allclose(
+    npt.assert_allclose(
         step.vars['current_A'],
         -1.*sim_wh.capacity,
         rtol=1e-3,

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -1,7 +1,9 @@
 import warnings
 
-import pytest
 import numpy as np
+import numpy.testing as npt
+
+import pytest
 import thevenin as thev
 import matplotlib.pyplot as plt
 
@@ -106,10 +108,10 @@ def test_append_step_soln(soln):
 
     t_new_times = t_orig[-1] + step0.vars['time_s']
     t_append = np.concatenate([t_orig, t_new_times])
-    np.testing.assert_allclose(soln.vars['time_s'], t_append)
+    npt.assert_allclose(soln.vars['time_s'], t_append)
 
     V_append = np.concatenate([V_orig, step0.vars['voltage_V']])
-    np.testing.assert_allclose(soln.vars['voltage_V'], V_append)
+    npt.assert_allclose(soln.vars['voltage_V'], V_append)
 
 
 def test_append_cycle_soln(soln):
@@ -122,10 +124,10 @@ def test_append_cycle_soln(soln):
 
     t_new_times = t_orig[-1] + t_orig
     t_append = np.concatenate([t_orig, t_new_times])
-    np.testing.assert_allclose(soln.vars['time_s'], t_append)
+    npt.assert_allclose(soln.vars['time_s'], t_append)
 
     V_append = np.concatenate([V_orig, V_orig])
-    np.testing.assert_allclose(soln.vars['voltage_V'], V_append)
+    npt.assert_allclose(soln.vars['voltage_V'], V_append)
 
 
 def test_append_w_events(rest, soln):


### PR DESCRIPTION
# Description
General cleanup. Makes sure tests use `np.testing.assert_*` where possible, and corrects a small mistake in the docs: `user_guide/model_description`. Specifically, hysteresis was missing from the final cell voltage equation.

## Type of change
- [x] Optimization (back-end change that improves speed/readability/etc.)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
