### PR TITLE
Missing hysteresis voltage in Qgen eqns (model & description)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Introduce `ExitHandler` to ensure `plt.show` doesn't get registered more than once, replaces `show_plot` option in `Solutions` ([#7](https://github.com/NREL/thevenin/pull/7))
 
 ### Bug Fixes
-None.
+- Hyseteresis voltage was missing in `Qgen` heat transfer terms, now incorporated ([#11](https://github.com/NREL/thevenin/pull/11))
 
 ### Breaking Changes
 - New hysteresis option means users will need to update old `params` inputs to also include `gamma` and `M_hyst` ([#7](https://github.com/NREL/thevenin/pull/7))

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $$mC_p\frac{dT_{\rm cell}}{dt} = Q_{\rm gen} + Q_{\rm conv},$$
 
 where $m$ is mass (kg), $C_p$ is specific heat capacity (J/kg/K), $Q_{\rm gen}$ is the heat generation (W), and $Q_{\rm conv}$ is the convective heat loss (W). Heat generation and convection are defined by
 
-$$Q_{\rm gen} = I \times (V_{\rm OCV}({\rm SOC}) - V_{\rm cell}),$$
+$$Q_{\rm gen} = I \times (V_{\rm OCV}({\rm SOC}) + h - V_{\rm cell}),$$
 $$Q_{\rm conv} = h_TA(T_{\infty} - T_{\rm cell}),$$
 
 where $h_T$ is the convecitive heat transfer coefficient (W/m<sup>2</sup>/K), $A$ is heat loss area (m<sup>2</sup>), and $T_{\infty}$ is the air/room temperature (K). $V_{\rm OCV}$ is the open circuit voltage (V) and is a function of SOC.

--- a/docs/source/user_guide/model_description.rst
+++ b/docs/source/user_guide/model_description.rst
@@ -41,7 +41,7 @@ where :math:`m` is mass (kg), :math:`C_p` is specific heat capacity (J/kg/K), :m
 .. math:: 
 
     \begin{align}
-      &\dot{Q}_{\rm gen} = I \times (V_{\rm OCV}({\rm SOC}) - V_{\rm cell}), \\
+      &\dot{Q}_{\rm gen} = I \times (V_{\rm OCV}({\rm SOC}) + h - V_{\rm cell}), \\
       &\dot{Q}_{\rm conv} = h_TA(T_{\infty} - T_{\rm cell}),
     \end{align}
 

--- a/src/thevenin/_basemodel.py
+++ b/src/thevenin/_basemodel.py
@@ -326,7 +326,7 @@ class BaseModel(ABC):
         rhs[ptr['soc']] = -ce*current*Q_inv
 
         # temperature (differential)
-        Q_gen = current*(ocv - voltage)
+        Q_gen = current*(ocv + hyst - voltage)
         Q_conv = self.h_therm*self.A_therm*(self.T_inf - T_cell)
 
         rhs[ptr['T_cell']] = alpha_inv * (Q_gen + Q_conv) \

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -445,11 +445,11 @@ def test_hysteresis():
     assert sim_wh.gamma == 50.
     assert sim_wh.M_hyst(0.) == 0.07
 
-    discharge = thev.Experiment()
+    discharge = thev.Experiment(max_step=10.)
     discharge.add_step('current_C', 1., (3600., 10.), limits=('soc', 0.5))
     discharge.add_step('current_A', 0., (600., 10.))
 
-    charge = thev.Experiment()
+    charge = thev.Experiment(max_step=10.)
     charge.add_step('current_C', -1., (3600., 10.), limits=('soc', 0.8))
     charge.add_step('current_A', 0., (600., 10.))
 
@@ -473,7 +473,7 @@ def test_hysteresis():
     npt.assert_allclose(soln.vars['hysteresis_V'][-1], -0.07, rtol=1e-4)
     npt.assert_almost_equal(
         soln.vars['voltage_V'][-1],
-        sim_woh.ocv(0.5) - 0.07,
+        sim_wh.ocv(0.5) - 0.07,
         decimal=2,
     )
 
@@ -481,7 +481,7 @@ def test_hysteresis():
     npt.assert_allclose(soln.vars['hysteresis_V'][-1], 0.07, rtol=1e-4)
     npt.assert_almost_equal(
         soln.vars['voltage_V'][-1],
-        sim_woh.ocv(0.8) + 0.07,
+        sim_wh.ocv(0.8) + 0.07,
         decimal=2,
     )
 


### PR DESCRIPTION
# Description
Hysteresis voltage was missing from the heat generation equation. It has now been added in both the documentation and internally in the model.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
