### PR TITLE
Bugfix/vary tinf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Introduce `ExitHandler` to ensure `plt.show` doesn't get registered more than once, replaces `show_plot` option in `Solutions` ([#7](https://github.com/NREL/thevenin/pull/7))
 
 ### Bug Fixes
+- Change to using `_T_ref` to scale the temperature equation since `T_inf` can be modified ([#12](https://github.com/NREL/thevenin/pull/12))
 - Hyseteresis voltage was missing in `Qgen` heat transfer terms, now incorporated ([#11](https://github.com/NREL/thevenin/pull/11))
 
 ### Breaking Changes

--- a/src/thevenin/_basemodel.py
+++ b/src/thevenin/_basemodel.py
@@ -197,6 +197,8 @@ class BaseModel(ABC):
             raise ValueError("'params' contains invalid and/or excess"
                              f" key/value pairs: {extra_keys=}")
 
+        self._T_ref = self.T_inf
+
         self.pre()
 
     def __repr__(self) -> str:  # pragma: no cover
@@ -298,7 +300,7 @@ class BaseModel(ABC):
 
         # state
         soc = sv[ptr['soc']]
-        T_cell = sv[ptr['T_cell']]*self.T_inf
+        T_cell = sv[ptr['T_cell']]*self._T_ref
         hyst = sv[ptr['hyst']]
         eta_j = sv[ptr['eta_j']]
 
@@ -308,7 +310,7 @@ class BaseModel(ABC):
 
         # dependent parameters
         Q_inv = 1. / (3600. * self.capacity)
-        alpha_inv = 1. / (self.mass * self.Cp * self.T_inf)
+        alpha_inv = 1. / (self.mass * self.Cp * self._T_ref)
 
         # current, voltage, and power - different for Simulation/Prediction
         if self._classname == 'Simulation':

--- a/src/thevenin/_prediction.py
+++ b/src/thevenin/_prediction.py
@@ -231,7 +231,7 @@ class Prediction(BaseModel):
 
         state = {}
         for k, v in ptr.items():
-            state[k] = array[v] * (self.T_inf if k == 'T_cell' else 1.)
+            state[k] = array[v] * (self._T_ref if k == 'T_cell' else 1.)
 
         return TransientState(**state)
 
@@ -266,7 +266,7 @@ class Prediction(BaseModel):
 
         sv = np.zeros(size)
         for k, v in ptr.items():
-            sv[v] = getattr(state, k) / (self.T_inf if k == 'T_cell' else 1.)
+            sv[v] = getattr(state, k) / (self._T_ref if k == 'T_cell' else 1.)
 
         return sv
 

--- a/src/thevenin/_simulation.py
+++ b/src/thevenin/_simulation.py
@@ -103,7 +103,7 @@ class Simulation(BaseModel):
 
         sv0 = np.zeros(ptr['size'])
         sv0[ptr['soc']] = self.soc0
-        sv0[ptr['T_cell']] = 1.
+        sv0[ptr['T_cell']] = 1. * self.T_inf / self._T_ref
         sv0[ptr['hyst']] = 0.
         sv0[ptr['eta_j']] = 0.
         sv0[ptr['V_cell']] = self.ocv(self.soc0)

--- a/src/thevenin/_simulation.py
+++ b/src/thevenin/_simulation.py
@@ -112,7 +112,7 @@ class Simulation(BaseModel):
 
         self._ptr = ptr
         self._algidx = algidx
-        self._mass_matrix = np.array(mass_matrix)
+        self._mass_matrix = mass_matrix
 
         self._t0 = 0.
         if isinstance(initial_state, BaseSolution):

--- a/src/thevenin/_solutions.py
+++ b/src/thevenin/_solutions.py
@@ -157,7 +157,7 @@ class BaseSolution(IDAResult):
         time = self.t
 
         soc = self.y[:, ptr['soc']]
-        T_cell = self.y[:, ptr['T_cell']]*sim.T_inf
+        T_cell = self.y[:, ptr['T_cell']]*sim._T_ref
         hyst = self.y[:, ptr['hyst']]
         eta_j = self.y[:, ptr['eta_j']]
         voltage = self.y[:, ptr['V_cell']]


### PR DESCRIPTION
# Description
Previously, the temperature equation was scaled using `T_inf`. However, since the code was updated to avoid requiring a `pre()` call when parameters change, this caused inconsistencies when `T_inf` was modified between experimental and prediction steps. To fix this, scaling now uses a hidden reference temperature `_T_ref`, set once during class initialization based on the original `T_inf`. Users should not modify `_T_ref`. This ensures consistent scaling across all experiment and prediction steps, even if `T_inf` changes later.

This change introduced nuanced behavior in the Simulation class. Consider the example below:

```python
sim = thev.Simulation()

sim.T_inf = 300
sim.isothermal = True
sim.pre()

expr = thev.Experiment()
expr.add_step('current_c', 1., (1000., 10.))

soln0 = sim.run(expr, reset_state=False)
soln0.plot('time_s', 'temperature_K')

sim.T_inf = 400

soln1 = sim.run(expr)
soln1.plot('time_s', 'temperature_K')
```

Originally, you might expect either (1) the temperature stays fixed at 300 K throughout due to `isothermal=True`, or (2) it updates from 300 K to 400 K because `T_inf` changed. Before this update, behavior followed option (2), which conflicted with the `Prediction` class, where `T_cell` always matches its input if `isothermal=True`, regardless of `T_inf`. To unify behavior, `Simulation` now also follows option (1).

Another case involves toggling `isothermal` between steps. In the snippet below, `soln0` might yield a final temperature of ~310 K after heating. If `isothermal=True` is enabled afterward, `soln1` retains this 310 K state -- even if `T_inf` is changed to 350 K -- because the internal state persists unless explicitly reset. By contrast, switching from `isothermal=True` to `False` does allow `T_inf` to influence temperature evolution.

To force the internal temperature to match a new `T_inf`, users must:

1) run a resting experiment to let the system equilibrate
2) call `pre()`, which resets the state accordingly

`Simulation` instances do not expose internal state, so modifying `T_inf` alone has no effect unless followed by one of these two actions.

```python
sim = thev.Simulation()

sim.T_inf = 300
sim.isothermal = False
sim.pre()

expr = thev.Experiment()
expr.add_step('current_c', 1., (1000., 10.))

soln0 = sim.run(expr, reset_state=False)
soln0.plot('time_s', 'temperature_K')

sim.T_inf = 350
sim.isothermal = True

soln1 = sim.run(expr)
soln1.plot('time_s', 'temperature_K')
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
