### PR TITLE
Remove ability to dynamically modify num_RC_pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added hysteresis (`hsyt`) to the model, controlled with `gamma` and `M_hyst` parameters ([#7](https://github.com/NREL/thevenin/pull/7))
 
 ### Optimizations
+- Make `num_RC_pairs` read-only so now `pre` only needs to be called to reset the state ([#13](https://github.com/NREL/thevenin/pull/13))
 - Use `np.testing` where possible in tests for more informative fail statements ([#10](https://github.com/NREL/thevenin/pull/10))
 - Pre-initialize `CycleSolution` arrays rather than appending lists, much faster ([#7](https://github.com/NREL/thevenin/pull/7))
 - Introduce `ExitHandler` to ensure `plt.show` doesn't get registered more than once, replaces `show_plot` option in `Solutions` ([#7](https://github.com/NREL/thevenin/pull/7))

--- a/src/thevenin/_basemodel.py
+++ b/src/thevenin/_basemodel.py
@@ -150,6 +150,12 @@ class BaseModel(ABC):
         not provide any resistance or capacitance values besides the series
         resistance R0, which is always required.
 
+        While most model parameters can be changed after initialization, the
+        ``num_RC_pairs`` is fixed. Consequently, you cannot add nor remove Rj
+        and Cj attributes. However, modifying the values of Rj and Cj functions
+        is allowed. If you need a circuit with a different number of RC pairs
+        then you will need to create a separate instance.
+
         """
 
         if isinstance(params, dict):
@@ -171,7 +177,7 @@ class BaseModel(ABC):
             'A_therm',
         ]
 
-        self.num_RC_pairs = params.pop('num_RC_pairs')
+        self._num_RC_pairs = params.pop('num_RC_pairs')
         self.soc0 = params.pop('soc0')
         self.capacity = params.pop('capacity')
         self.ce = params.pop('ce')
@@ -187,6 +193,10 @@ class BaseModel(ABC):
         self.R0 = params.pop('R0')
 
         for j in range(1, self.num_RC_pairs + 1):
+
+            assert 'R' + str(j) in params, f"'params' is missing R{str(j)}"
+            assert 'C' + str(j) in params, f"'params' is missing C{str(j)}"
+
             setattr(self, 'R' + str(j), params.pop('R' + str(j)))
             setattr(self, 'C' + str(j), params.pop('C' + str(j)))
 
@@ -224,6 +234,11 @@ class BaseModel(ABC):
     def classname(self) -> str:
         """Return the name of the class."""
         return self.__class__.__name__
+
+    @property
+    def num_RC_pairs(self) -> int:
+        """Return the number of RC pairs."""
+        return self._num_RC_pairs
 
     @property
     def _classname(self) -> str:

--- a/src/thevenin/_basemodel.py
+++ b/src/thevenin/_basemodel.py
@@ -150,9 +150,9 @@ class BaseModel(ABC):
         not provide any resistance or capacitance values besides the series
         resistance R0, which is always required.
 
-        While most model parameters can be changed after initialization, the
-        ``num_RC_pairs`` is fixed. Consequently, you cannot add nor remove Rj
-        and Cj attributes. However, modifying the values of Rj and Cj functions
+        While most parameters can be dynamically updated, the ``num_RC_pairs``
+        attribute is read-only. Consequently, you cannot add nor remove Rj and
+        Cj attributes. However, modifying the values of Rj and Cj functions
         is allowed. If you need a circuit with a different number of RC pairs
         then you will need to create a separate instance.
 

--- a/src/thevenin/_prediction.py
+++ b/src/thevenin/_prediction.py
@@ -96,11 +96,18 @@ class Prediction(BaseModel):
 
     This class is primarily intended for prediction-correction algorithms,
     e.g., Kalman filters. The interface is set up to let the user manage the
-    internal state via the :class:`~thevenin.TransientState` class. In addition
+    internal state via the :class:`~thevenin.TransientState` class. In addition,
     the model is only designed to run current-based loads in a step-by-step
     fashion. If you are looking to simulate more complex protocols and use the
     resulting timeseries data you should use the :class:`~thevenin.Simulation`
     class instead.
+
+    Note that this class and the :class:`~thevenin.Simulation` class share the
+    same ``params`` inputs. This is for convenience so that users can easily
+    switch between the two. However, the 'soc0' value has no real meaning for
+    the prediction interface. Instead, the user manages the state of charge for
+    each step through the ``TransientState`` interface. This means that you can
+    effectively ignore the 'soc0' input when using this class.
 
     """
 
@@ -109,18 +116,17 @@ class Prediction(BaseModel):
         Pre-process and prepare the model to make predictions. Specifically,
         this method builds pointers so it can manage mapping the state back
         and forth between the solver-required array format and the user-managed
-        ``TransientState`` class. So long as you do not change the size of the
-        circuit by dynamically modifying ``num_RC_pairs`` and any corresponding
-        resistor/capacitor attributes then this method will never need to be
-        run manually. In fact, we highly recommended that users not adjust
-        ``num_RC_pairs``. Instead, if you need a new circuit with a different
-        number of RC pairs, you should create a new instance of the model. If
-        you follow this recommendation you are less likely to run into complex
-        errors that can arise.
+        ``TransientState`` class.
 
         Returns
         -------
         None.
+
+        Notes
+        -----
+        This method runs during the class initialization. It generally does not
+        have to be run again unless you want to re-run internal checks on the
+        class instance.
 
         """
 

--- a/tests/test_loadfns.py
+++ b/tests/test_loadfns.py
@@ -70,21 +70,21 @@ def test_ramp_2_constant():
 def test_step_function():
 
     # Inputs must be 1D
+    tp = np.array([[0, 1, 5]])
+    yp = np.array([-1, 0, 1])
     with pytest.raises(ValueError):
-        tp = np.array([[0, 1, 5]])
-        yp = np.array([-1, 0, 1])
         _ = thev.loadfns.StepFunction(tp, yp)
 
     # Inputs must be same length
+    tp = np.array([0, 1])
+    yp = np.array([-1, 0, 1])
     with pytest.raises(ValueError):
-        tp = np.array([0, 1])
-        yp = np.array([-1, 0, 1])
         _ = thev.loadfns.StepFunction(tp, yp)
 
     # tp must be strictly increasing
+    tp = np.array([0, -1, 5])
+    yp = np.array([-1, 0, 1])
     with pytest.raises(ValueError):
-        tp = np.array([0, -1, 5])
-        yp = np.array([-1, 0, 1])
         _ = thev.loadfns.StepFunction(tp, yp)
 
     tp = np.array([0, 1, 5])
@@ -106,27 +106,27 @@ def test_step_function():
 def test_ramped_steps():
 
     # Inputs must be 1D
+    tp = np.array([[0, 1, 5]])
+    yp = np.array([-1, 0, 1])
     with pytest.raises(ValueError):
-        tp = np.array([[0, 1, 5]])
-        yp = np.array([-1, 0, 1])
         _ = thev.loadfns.RampedSteps(tp, yp, 1.)
 
     # Inputs must be same length
+    tp = np.array([0, 1])
+    yp = np.array([-1, 0, 1])
     with pytest.raises(ValueError):
-        tp = np.array([0, 1])
-        yp = np.array([-1, 0, 1])
         _ = thev.loadfns.RampedSteps(tp, yp, 1.)
 
     # t_ramp must be strictly positive
+    tp = np.array([0, 1, 5])
+    yp = np.array([-1, 0, 1])
     with pytest.raises(ValueError):
-        tp = np.array([0, 1, 5])
-        yp = np.array([-1, 0, 1])
         _ = thev.loadfns.RampedSteps(tp, yp, 0.)
 
     # tp must be strictly increasing
+    tp = np.array([0, -1, 5])
+    yp = np.array([-1, 0, 1])
     with pytest.raises(ValueError):
-        tp = np.array([0, -1, 5])
-        yp = np.array([-1, 0, 1])
         _ = thev.loadfns.RampedSteps(tp, yp, 1.)
 
     tp = np.array([0, 1, 5])


### PR DESCRIPTION
# Description
Requiring `pre()` after every parameter change was inconvenient and made state management error-prone. To simplify this, the governing equations were updated so that the mass matrix no longer depends on any parameters.

The only exception was `num_RC_pairs`, which changes the system size and requires reinitialization. To avoid complexity, it is now a read-only property. All other parameters remain dynamically adjustable.

## Type of change
- [x] Optimization (back-end change that improves speed/readability/etc.)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
