### PR TITLE
Fix float-only post-processing steps in v0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # thevenin Changelog
 
+## [Unreleased](https://github.com/NREL/thevenin)
+
+### New Features
+
+### Optimizations
+
+### Bug Fixes
+
+### Breaking Changes
+
+## [v0.2.1](https://github.com/NREL/thevenin/tree/v0.2.1)
+
+### Bug Fixes
+- Use `for` loops in `Solution` post-processing if arrays are incompatible ()
+
 ## [v0.2.0](https://github.com/NREL/thevenin/tree/v0.2.0)
 
 ### New Features

--- a/images/tests.svg
+++ b/images/tests.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 43">
-	<title>tests: 43</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 44">
+	<title>tests: 44</title>
 	<linearGradient id="s" x2="0" y2="100%">
 		<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
 		<stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
 	<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
 		<text aria-hidden="true" x="195.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">tests</text>
 		<text x="195.0" y="140" transform="scale(.1)" fill="#fff" textLength="270">tests</text>
-		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">43</text>
-		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">43</text>
+		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">44</text>
+		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">44</text>
 	</g>
 </svg>

--- a/scripts/version_checker.py
+++ b/scripts/version_checker.py
@@ -123,7 +123,7 @@ if __name__ == '__main__':
 
     patch_check = Version(args.local)
     if patch_check.micro > 0:
-        prefix = str(patch_check.major) + '.' + str(patch_check.minor)
+        prefix = str(patch_check.major) + '.' + str(patch_check.minor) + '.'
     else:
         prefix = None
 

--- a/src/thevenin/__init__.py
+++ b/src/thevenin/__init__.py
@@ -28,7 +28,7 @@ from . import loadfns
 from . import plotutils
 from . import solvers
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 __all__ = [
     'Experiment',

--- a/src/thevenin/_solutions.py
+++ b/src/thevenin/_solutions.py
@@ -162,8 +162,22 @@ class BaseSolution(IDAResult):
         eta_j = self.y[:, ptr['eta_j']]
         voltage = self.y[:, ptr['V_cell']]
 
-        ocv = sim.ocv(soc)
-        R0 = sim.R0(soc, T_cell)
+        try:
+            ocv = sim.ocv(soc)
+            R0 = sim.R0(soc, T_cell)
+
+            assert isinstance(ocv, np.ndarray)
+            assert isinstance(R0, np.ndarray)
+            assert ocv.shape == soc.shape
+            assert R0.shape == soc.shape
+
+        except (TypeError, AssertionError):
+
+            ocv = np.empty_like(soc)
+            R0 = np.empty_like(soc)
+            for i in range(soc.size):
+                ocv[i] = sim.ocv(soc[i])
+                R0[i] = sim.R0(soc[i], T_cell[i])
 
         current = calculated_current(voltage, ocv, hyst, eta_j, R0)
 


### PR DESCRIPTION
# Description
Post-processing steps in the Solution object assumed that the ocv and R0 functions were compatible with numpy arrays. Since the documentation states that only f(float, float) -> float functions are expected, it is not guaranteed that numpy arrays will (or should) be compatible. The process now tries to evaluate with numpy arrays (for computational efficiency), but if this is not possible then values are obtained by looping over the soc and T_cell timeseries outputs.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
