### PR TITLE
Fix float-only post-processing steps in v0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 ### Optimizations
 
 ### Bug Fixes
-- Use `for` loops in `Solution` post-processing if arrays are incompatible ()
+- Use `for` loops in `Solution` post-processing if arrays are incompatible ([#18](https://github.com/NREL/thevenin/pull/18))
 
 ### Breaking Changes
 - `initial_state` was renamed to `state0` in `sim.pre()` ([#14](https://github.com/NREL/thevenin/pull/14))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Optimizations
 
 ### Bug Fixes
+- Use `for` loops in `Solution` post-processing if arrays are incompatible ()
 
 ### Breaking Changes
 - `initial_state` was renamed to `state0` in `sim.pre()` ([#14](https://github.com/NREL/thevenin/pull/14))

--- a/images/tests.svg
+++ b/images/tests.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 43">
-	<title>tests: 43</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 44">
+	<title>tests: 44</title>
 	<linearGradient id="s" x2="0" y2="100%">
 		<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
 		<stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
 	<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
 		<text aria-hidden="true" x="195.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">tests</text>
 		<text x="195.0" y="140" transform="scale(.1)" fill="#fff" textLength="270">tests</text>
-		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">43</text>
-		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">43</text>
+		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">44</text>
+		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">44</text>
 	</g>
 </svg>

--- a/scripts/version_checker.py
+++ b/scripts/version_checker.py
@@ -123,7 +123,7 @@ if __name__ == '__main__':
 
     patch_check = Version(args.local)
     if patch_check.micro > 0:
-        prefix = str(patch_check.major) + '.' + str(patch_check.minor)
+        prefix = str(patch_check.major) + '.' + str(patch_check.minor) + '.'
     else:
         prefix = None
 

--- a/src/thevenin/_solutions.py
+++ b/src/thevenin/_solutions.py
@@ -162,8 +162,22 @@ class BaseSolution(IDAResult):
         eta_j = self.y[:, ptr['eta_j']]
         voltage = self.y[:, ptr['V_cell']]
 
-        ocv = sim.ocv(soc)
-        R0 = sim.R0(soc, T_cell)
+        try:
+            ocv = sim.ocv(soc)
+            R0 = sim.R0(soc, T_cell)
+
+            assert isinstance(ocv, np.ndarray)
+            assert isinstance(R0, np.ndarray)
+            assert ocv.shape == soc.shape
+            assert R0.shape == soc.shape
+
+        except (TypeError, AssertionError):
+
+            ocv = np.empty_like(soc)
+            R0 = np.empty_like(soc)
+            for i in range(soc.size):
+                ocv[i] = sim.ocv(soc[i])
+                R0[i] = sim.R0(soc[i], T_cell[i])
 
         current = calculated_current(voltage, ocv, hyst, eta_j, R0)
 

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -168,3 +168,41 @@ def test_append_w_events(rest, soln):
 
     rest.append_soln(soln)
     assert len(rest.t_events) == 2
+
+
+def test_np_incompatible_funcs():
+
+    def ocv(soc):
+        if isinstance(soc, np.ndarray):
+            raise TypeError("ocv cannot accept numpy arrays.")
+        return 3.8
+
+    def R0(soc, T_cell):
+        if isinstance(soc, np.ndarray):
+            raise TypeError("R0 cannot accept numpy arrays.")
+        elif isinstance(T_cell, np.ndarray):
+            raise TypeError("R0 cannot accept numpy arrays.")
+        return 3.8
+
+    expr = thev.Experiment()
+    expr.add_step('current_A', 0., (100., 1.))
+
+    # with ocv that cannot handle numpy arrays
+    params = dict_params(0)
+    params['ocv'] = ocv
+
+    model = thev.Model(params)
+    soln = model.run(expr)
+
+    assert soln.success
+    npt.assert_allclose(soln.vars['voltage_V'], 3.8)
+
+    # with R0 that cannot handle numpy arrays
+    params = dict_params(0)
+    params['R0'] = R0
+
+    model = thev.Model(params)
+    soln = model.run(expr)
+
+    assert soln.success
+    npt.assert_allclose(soln.vars['eta0_V'], 0.)


### PR DESCRIPTION
# Description
Post-processing steps in the Solution object assumed that the ocv and R0 functions were compatible with numpy arrays. Since the documentation states that only f(float, float) -> float functions are expected, it is not guaranteed that numpy arrays will (or should) be compatible. The process now tries to evaluate with numpy arrays (for computational efficiency), but if this is not possible then values are obtained by looping over the soc and T_cell timeseries outputs.

Fixes #19 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
