### PR TITLE
Add to_...() methods to switch between interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/NREL/thevenin)
 
 ### New Features
+- Add `to_simulation` and `to_prediction` methods to switch between interfaces ([#20](https://github.com/NREL/thevenin/pull/20))
 - Allow `TransientState` as an input option to `sim.pre()` ([#14](https://github.com/NREL/thevenin/pull/14))
 
 ### Optimizations

--- a/images/tests.svg
+++ b/images/tests.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 44">
-	<title>tests: 44</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="62" height="20" role="img" aria-label="tests: 46">
+	<title>tests: 46</title>
 	<linearGradient id="s" x2="0" y2="100%">
 		<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
 		<stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
 	<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
 		<text aria-hidden="true" x="195.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="270">tests</text>
 		<text x="195.0" y="140" transform="scale(.1)" fill="#fff" textLength="270">tests</text>
-		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">44</text>
-		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">44</text>
+		<text aria-hidden="true" x="485.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="150">46</text>
+		<text x="485.0" y="140" transform="scale(.1)" fill="#fff" textLength="150">46</text>
 	</g>
 </svg>

--- a/src/thevenin/_basemodel.py
+++ b/src/thevenin/_basemodel.py
@@ -248,6 +248,24 @@ class BaseModel(ABC):
 
         return self.classname
 
+    @property
+    def _get_params_dict(self) -> dict:
+        """Return the params dictionary needed to initialize a new instance."""
+
+        params = {}
+        for k in self._repr_keys:
+            params[k] = getattr(self, k)
+
+        params['ocv'] = self.ocv
+        params['M_hyst'] = self.M_hyst
+        params['R0'] = self.R0
+
+        for j in range(1, self.num_RC_pairs + 1):
+            params['R' + str(j)] = getattr(self, 'R' + str(j))
+            params['C' + str(j)] = getattr(self, 'C' + str(j))
+
+        return params
+
     @abstractmethod
     def pre(self, *args, **kwargs) -> None:  # pragma: no cover
         """Preprocessor: ensure model setup is correct and ready to run."""

--- a/src/thevenin/_prediction.py
+++ b/src/thevenin/_prediction.py
@@ -247,7 +247,7 @@ class Prediction(BaseModel):
         -------
         :class:`~thevenin.Simulation`
             An instance of the Simulation interface, initialized with the same
-            properties ass the current Prediction instance.
+            properties as the current Prediction instance.
 
         Notes
         -----

--- a/src/thevenin/_simulation.py
+++ b/src/thevenin/_simulation.py
@@ -10,7 +10,7 @@ from thevenin._basemodel import BaseModel
 
 if TYPE_CHECKING:  # pragma: no cover
     from ._experiment import Experiment
-    from ._prediction import TransientState
+    from ._prediction import Prediction, TransientState
     from ._solutions import BaseSolution, StepSolution, CycleSolution
 
     Solution = TypeVar('Solution', bound='BaseSolution')
@@ -254,6 +254,23 @@ class Simulation(BaseModel):
             self.pre()
 
         return soln
+
+    def to_prediction(self) -> Prediction:
+        """
+        Generate a ``Prediction`` class instance with the same properties as
+        the current ``Simulation``.
+
+        Returns
+        -------
+        :class:`~thevenin.Prediction`
+            An instance of the Prediction interface, initialized with the same
+            properties ass the current Simulation instance.
+
+        """
+
+        from ._prediction import Prediction
+
+        return Prediction(self._get_params_dict)
 
     def _resfn(self, t: float, sv: np.ndarray, svdot: np.ndarray,
                res: np.ndarray, userdata: dict) -> None:

--- a/src/thevenin/_simulation.py
+++ b/src/thevenin/_simulation.py
@@ -264,7 +264,7 @@ class Simulation(BaseModel):
         -------
         :class:`~thevenin.Prediction`
             An instance of the Prediction interface, initialized with the same
-            properties ass the current Simulation instance.
+            properties as the current Simulation instance.
 
         """
 

--- a/tests/test_prediction.py
+++ b/tests/test_prediction.py
@@ -133,3 +133,11 @@ def test_incompatible_state():
 
     with pytest.raises(ValueError):
         _ = pred.take_step(state, 0., 1.)
+
+
+def test_to_simulation():
+
+    pred = thev.Prediction()
+    sim = pred.to_simulation()
+
+    assert pred._get_params_dict == sim._get_params_dict

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -513,3 +513,11 @@ def test_hysteresis():
         -1.*sim_wh.capacity,
         rtol=1e-3,
     )
+
+
+def test_to_prediction():
+
+    sim = thev.Simulation()
+    pred = sim.to_prediction()
+
+    assert sim._get_params_dict == pred._get_params_dict


### PR DESCRIPTION
# Description
Add `to_simulation()` and `to_prediction()` methods that allow easier switching between the interfaces. This is helpful for state estimation algorithms where the user may want to use the `Prediction` interface for step-by-step state estimation, but also wants to periodically use the `Simulation` for more prognostic-like estimations, e.g., remaining energy.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.
